### PR TITLE
Release corrected audit packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,11 @@ This file records user-visible changes to HIG Doctor's published CLI, MCP server
 
 - No release notes recorded yet.
 
+## Core 0.1.2, CLI 2.0.2, and MCP 0.2.2 — 2026-09-02
+
+- Corrected JSX hover and focus matching so handlers on separate elements
+  cannot hide an accessibility concern.
+- Published the corrected engine in the core package, CLI bundle, and MCP
+  audit tools.
+
 Published release history is also available in [GitHub releases](https://github.com/raintree-technology/hig-doctor/releases). Generated rule-count and benchmark changes must link to their regenerated evidence and must not be described as field accuracy or HIG conformance.

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "packages/cli": {
       "name": "hig-doctor",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "bin": {
         "hig-doctor": "dist/index.js",
       },
@@ -33,7 +33,7 @@
     },
     "packages/core": {
       "name": "@raintree-technology/hig-doctor-core",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "devDependencies": {
         "@types/bun": "^1.3.3",
         "@types/node": "^20",
@@ -46,7 +46,7 @@
     },
     "packages/mcp": {
       "name": "hig-mcp",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "bin": {
         "hig-mcp": "dist/index.js",
       },

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to `hig-doctor` (the Apple HIG audit CLI) are documented her
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.2] - 2026-09-02
+
+### Fixed
+
+- Bundle the corrected element-scoped hover and focus accessibility matching
+  from the audit engine.
+
 ## [2.0.1] - 2026-07-26
 
 ### Fixed

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hig-doctor",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "HIG Doctor universal Apple HIG compliance auditor for SwiftUI, UIKit, React, and 11 other frameworks.",
   "type": "module",
   "bin": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to `@raintree-technology/hig-doctor-core` are documented her
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2026-09-02
+
+### Fixed
+
+- Match `onMouseOver` and `onMouseOut` accessibility concerns within one JSX
+  element so handlers on separate elements cannot satisfy each other.
+- Preserve valid `onFocus` and `onBlur` counterparts regardless of their
+  attribute order or line position inside the element.
+
 ## [0.1.1] - 2026-07-26
 
 ### Fixed

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raintree-technology/hig-doctor-core",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Rule engine powering HIG Doctor: framework detection, Apple HIG pattern rules, and the audit pipeline.",
   "type": "module",
   "license": "MIT",

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -6,6 +6,13 @@ are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - 2026-09-02
+
+### Fixed
+
+- Bundle the corrected element-scoped hover and focus accessibility matching
+  for `hig_audit` and `hig_audit_file`.
+
 ## [0.2.1] - 2026-07-26
 
 ### Fixed

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hig-mcp",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "mcpName": "io.github.raintree-technology/hig-doctor",
   "description": "HIG Doctor MCP server exposing Apple HIG skills and project audits to AI coding agents",
   "type": "module",


### PR DESCRIPTION
## Summary

- release @raintree-technology/hig-doctor-core 0.1.2
- release hig-doctor 2.0.2
- release hig-mcp 0.2.2
- document the element-scoped hover and focus matching fix in each package changelog

## Checks

- frozen lockfile installation
- full repository validation
- npm package dry runs for all three packages
- staged diff whitespace check
- repository secret scan

All checks passed locally.